### PR TITLE
minor maintenance fix

### DIFF
--- a/pr2_reachability_costmap/manifest.xml
+++ b/pr2_reachability_costmap/manifest.xml
@@ -8,9 +8,10 @@
   <license>BSD</license>
   <review status="unreviewed" notes="" />
   <url>http://ros.org/wiki/pr2_reachability_costmap</url>
-  <depend package="kinematics_msgs" />
+  <depend package="iai_kinematics_msgs" />
   <depend package="location_costmap" />
-  <depend package="roslisp_runtime" />
+  <rosdep name="sbcl" />
+  <depend package="roslisp" />
   <depend package="cl_transforms" />
   <depend package="cl_tf" />
   <depend package="cram_utilities" />

--- a/pr2_reachability_costmap/pr2-reachability-costmap.asd
+++ b/pr2_reachability_costmap/pr2-reachability-costmap.asd
@@ -40,7 +40,7 @@
                cram-roslisp-common
                cram-manipulation-knowledge
                designators-ros
-               kinematics_msgs-srv)
+               iai_kinematics_msgs-srv)
   :components
   ((:module "src"
     :components

--- a/pr2_reachability_costmap/src/ros.lisp
+++ b/pr2_reachability_costmap/src/ros.lisp
@@ -40,7 +40,7 @@
         (setf (gethash name *persistent-ik-services*)
               (make-instance 'roslisp:persistent-service
                 :service-name name
-                :service-type "kinematics_msgs/GetPositionIK")))))
+                :service-type "iai_kinematics_msgs/GetPositionIK")))))
 
 (defun get-ik-solver-info (namespace)
   (or (gethash namespace *ik-solver-info*)
@@ -48,7 +48,7 @@
             (roslisp:with-fields (kinematic_solver_info)
                 (roslisp:call-service
                  (concatenate 'string namespace "/get_ik_solver_info")
-                 "kinematics_msgs/GetKinematicSolverInfo")
+                 "iai_kinematics_msgs/GetKinematicSolverInfo")
               kinematic_solver_info))))
 
 (defun get-ik-solver-joints (namespace)
@@ -82,7 +82,7 @@
         (roslisp:call-persistent-service
          (get-persistent-service (concatenate 'string service-namespace "/get_ik"))
          (roslisp:make-request
-          "kinematics_msgs/GetPositionIK"
+          "iai_kinematics_msgs/GetPositionIK"
           (:ik_link_name :ik_request) ik-link
           (:pose_stamped :ik_request) (tf:pose-stamped->msg
                                        (tf:pose->pose-stamped ik-base-frame 0.0 pose))


### PR DESCRIPTION
- renamed kinematic_msgs into iai_kinematics_msgs
- got rid of roslisp_runtime dependency

The package iai_kinematics_msgs is a part of iai_common_msgs repo.
