### PR TITLE
tf -> tf2

### DIFF
--- a/point_head_process_module/src/package.lisp
+++ b/point_head_process_module/src/package.lisp
@@ -38,7 +38,7 @@
         #:alexandria
         #:cpl-impl)
   (:export #:point-head-process-module)
-  (:import-from cram-roslisp-common *tf2*)
+  (:import-from cram-roslisp-common *tf2-buffer*)
   (:shadowing-import-from #:cpl-impl #:fail)
   (:shadowing-import-from #:cram-process-modules #:name)
   (:desig-properties #:to #:see #:follow #:pose #:location #:obj))

--- a/pr2_manipulation_knowledge/src/kinematics.lisp
+++ b/pr2_manipulation_knowledge/src/kinematics.lisp
@@ -32,10 +32,10 @@
 (defgeneric make-orientation-euler (x y z))
 
 (defmethod make-orientation (x y z w)
-  (tf:make-quaternion x y z w))
+  (cl-transforms:make-quaternion x y z w))
 
 (defmethod make-orientation-euler (x y z)
-  (tf:euler->quaternion :ax x :ay y :az z))
+  (cl-transforms:euler->quaternion :ax x :ay y :az z))
 
 (def-fact-group robot-kinematics (manipulator-link
                                   manipulator-identity-orientation

--- a/pr2_manipulation_knowledge/src/pick-and-place.lisp
+++ b/pr2_manipulation_knowledge/src/pick-and-place.lisp
@@ -30,10 +30,10 @@
 
 (defun find-designator-pose-in-link (gripper-link designator)
   (find-if (lambda (pose-frame-id)
-             (equal (tf::ensure-fully-qualified-name gripper-link)
-                    (tf::ensure-fully-qualified-name pose-frame-id)))
+             (equal (cl-tf2:unslash-frame gripper-link)
+                    (cl-tf2:unslash-frame pose-frame-id)))
            (desig-prop-values designator 'pose)
-           :key #'tf:frame-id))
+           :key #'cl-tf-datatypes:frame-id))
 
 (defun get-latest-detected-object-pose (object-designator)
   "Returns the pose where the object has been detected using
@@ -62,7 +62,7 @@
 
 (defun calculate-put-down-hand-pose (gripper-link object-designator put-down-pose
                                      &key robot-pose)
-  (declare (type tf:pose-stamped put-down-pose))
+  (declare (type cl-tf-datatypes:pose-stamped put-down-pose))
   (let ((current-object (desig:current-desig object-designator)))
     (desig:with-desig-props (desig-props:at) current-object
       (assert desig-props:at () "Object ~a needs to have an `at' property"
@@ -72,18 +72,20 @@
                 "Object ~a needs to be in the gripper" current-object)
         (assert z-offset () "Object ~a needs to have a `z-offset' property" current-object)
         (let* ((pose-in-gripper (find-designator-pose-in-link gripper-link at))
-               (put-down-pose-in-fixed-frame  (tf:transform-pose
-                                               cram-roslisp-common:*tf*
-                                               :target-frame designators-ros:*fixed-frame*
-                                               :pose put-down-pose))
+               (put-down-pose-in-fixed-frame
+                 (cl-tf2:transform-pose
+                  cram-roslisp-common:*tf2-buffer*
+                  :target-frame designators-ros:*fixed-frame*
+                  :pose put-down-pose
+                  :timeout cram-roslisp-common:*tf-default-timeout*))
                (put-down-pose (if (not robot-pose)
                                   put-down-pose-in-fixed-frame
-                                  (tf:copy-pose-stamped
+                                  (cl-tf-datatypes:copy-pose-stamped
                                    put-down-pose-in-fixed-frame
                                    :orientation (cl-transforms:q*
-                                                 (tf:orientation
+                                                 (cl-transforms:orientation
                                                   (find-designator-pose-in-link "base_footprint" at))
-                                                 (tf:orientation robot-pose))))))
+                                                 (cl-transforms:orientation robot-pose))))))
           (assert pose-in-gripper () "Object ~a needs to have a `pose' property" current-object)
           (cl-transforms:transform->pose
            (cl-transforms:transform*
@@ -94,7 +96,7 @@
             (cl-transforms:transform-inv
              (cl-transforms:transform*
               (cl-transforms:make-transform
-               (tf:v* (get-tool-vector) -1)
+               (cl-transforms:v* (get-tool-vector) -1)
                (cl-transforms:make-identity-rotation))
               (cl-transforms:pose->transform pose-in-gripper))))))))))
 

--- a/pr2_manipulation_process_module/src/collision-environment.lisp
+++ b/pr2_manipulation_process_module/src/collision-environment.lisp
@@ -86,8 +86,8 @@
   (let ((pose-tf (cl-transforms:reference-transform pose)))
     (roslisp:make-msg
      "sensor_msgs/PointCloud"
-     (stamp header) (tf:stamp pose)
-     (frame_id header) (tf:frame-id pose)
+     (stamp header) (cl-tf-datatypes:stamp pose)
+     (frame_id header) (cl-tf-datatypes:frame-id pose)
      points (map 'vector
                  (lambda (p)
                    (roslisp:with-fields (x y z) p

--- a/pr2_manipulation_process_module/src/designator.lisp
+++ b/pr2_manipulation_process_module/src/designator.lisp
@@ -31,7 +31,7 @@
   (apply #'roslisp::make-message-fn type-str slots))
 
 (defun arm-for-pose (pose)
-  (let* ((pose-frame (tf:frame-id pose))
+  (let* ((pose-frame (cl-tf-datatypes:frame-id pose))
          (string-frame
            (or (when (and (> (length pose-frame) 0)
                           (string= (subseq pose-frame 0 1) "/"))
@@ -45,9 +45,9 @@
   "Adds custom offsets to gripper poses based on their arm `side'. This is mainly intended for customly adapted robots that need special handling for gripper sides."
   ;; TODO(winkler): Move this function into `userspace' in order to not interfer with other scenarios' robot (PR2) setups.
   (ecase side
-    (:left (tf:make-pose (tf:make-3d-vector -0.035 0.0 0.0)
-                         (tf:make-identity-rotation)))
-    (:right (tf:make-identity-pose))))
+    (:left (cl-transforms:make-pose (cl-transforms:make-3d-vector -0.035 0.0 0.0)
+                                    (cl-transforms:make-identity-rotation)))
+    (:right (cl-transforms:make-identity-pose))))
 
 (defun no-trailing-zeros (lst)
   (cond ((= 0 (car (last lst)))
@@ -143,22 +143,22 @@
     maybe-sorted-combos))
 
 (defun orient-pose (pose-stamped z-rotation)
-  (let* ((orig-orient (tf:orientation pose-stamped))
-         (tran-orient (tf:orientation
+  (let* ((orig-orient (cl-transforms:orientation pose-stamped))
+         (tran-orient (cl-transforms:orientation
                        (cl-transforms:transform-pose
-                        (tf:make-transform
-                         (tf:make-identity-vector)
-                         (tf:euler->quaternion :az z-rotation))
-                        (tf:make-pose
-                         (tf:make-identity-vector) orig-orient)))))
-    (tf:make-pose-stamped
-     (tf:frame-id pose-stamped) (ros-time)
-     (tf:origin pose-stamped) tran-orient)))
+                        (cl-transforms:make-transform
+                         (cl-transforms:make-identity-vector)
+                         (cl-transforms:euler->quaternion :az z-rotation))
+                        (cl-transforms:make-pose
+                         (cl-transforms:make-identity-vector) orig-orient)))))
+    (cl-tf-datatypes:make-pose-stamped
+     (cl-tf-datatypes:frame-id pose-stamped) (ros-time)
+     (cl-transforms:origin pose-stamped) tran-orient)))
 
 (defun elevate-pose (pose-stamped z-offset)
-  (tf:copy-pose-stamped
-   pose-stamped :origin (tf:v+ (tf:origin pose-stamped)
-                               (tf:make-3d-vector 0.0 0.0 z-offset))))
+  (cl-tf-datatypes:copy-pose-stamped
+   pose-stamped :origin (cl-transforms:v+ (cl-transforms:origin pose-stamped)
+                                          (cl-transforms:make-3d-vector 0.0 0.0 z-offset))))
 
 (defun rotated-poses (pose &key segments (z-offset 0.0))
   (let ((segments (or segments 8)))

--- a/pr2_manipulation_process_module/src/grasping.lisp
+++ b/pr2_manipulation_process_module/src/grasping.lisp
@@ -28,68 +28,68 @@
 (in-package :pr2-manipulation-process-module)
 
 (defparameter *pregrasp-offset*
-  (tf:make-pose
-   (tf:make-3d-vector
+  (cl-transforms:make-pose
+   (cl-transforms:make-3d-vector
     -0.29 0.0 0.0)
-   (tf:euler->quaternion :ax (/ pi -2))))
+   (cl-transforms:euler->quaternion :ax (/ pi -2))))
 (defparameter *pregrasp-top-slide-down-offset*
-  (tf:make-pose
-   (tf:make-3d-vector
+  (cl-transforms:make-pose
+   (cl-transforms:make-3d-vector
     -0.20 0.10 0.0)
-   (tf:euler->quaternion :ax (/ pi -2))))
+   (cl-transforms:euler->quaternion :ax (/ pi -2))))
 (defparameter *grasp-offset*
-  (tf:make-pose
-   (tf:make-3d-vector
+  (cl-transforms:make-pose
+   (cl-transforms:make-3d-vector
     -0.20 0.0 0.0)
-   (tf:euler->quaternion :ax (/ pi -2))))
+   (cl-transforms:euler->quaternion :ax (/ pi -2))))
 (defparameter *pre-putdown-offset*
-  (tf:make-pose
-   (tf:make-3d-vector
+  (cl-transforms:make-pose
+   (cl-transforms:make-3d-vector
     0.0 0.0 0.2)
-   (tf:euler->quaternion)))
+   (cl-transforms:euler->quaternion)))
 (defparameter *putdown-offset*
-  (tf:make-pose
-   (tf:make-3d-vector
+  (cl-transforms:make-pose
+   (cl-transforms:make-3d-vector
     0.0 0.0 0.02)
-   (tf:euler->quaternion)))
+   (cl-transforms:euler->quaternion)))
 (defparameter *unhand-offset*
-  (tf:make-pose
-   (tf:make-3d-vector
+  (cl-transforms:make-pose
+   (cl-transforms:make-3d-vector
     -0.10 0.0 0.02)
-   (tf:euler->quaternion)))
+   (cl-transforms:euler->quaternion)))
 (defparameter *unhand-top-slide-down-offset*
-  (tf:make-pose
-   (tf:make-3d-vector
+  (cl-transforms:make-pose
+   (cl-transforms:make-3d-vector
     0.0 0.0 0.10)
-   (tf:euler->quaternion)))
+   (cl-transforms:euler->quaternion)))
 
 ;; Parking related poses
 (defparameter *park-pose-left-default*
-  (tf:make-pose-stamped
+  (cl-tf-datatypes:make-pose-stamped
    "base_link" (ros-time)
-   (tf:make-3d-vector 0.3 0.5 1.3)
-   (tf:euler->quaternion :ax 0)))
+   (cl-transforms:make-3d-vector 0.3 0.5 1.3)
+   (cl-transforms:euler->quaternion :ax 0)))
 (defparameter *park-pose-right-default*
-  (tf:make-pose-stamped
+  (cl-tf-datatypes:make-pose-stamped
    "base_link" (ros-time)
-   (tf:make-3d-vector 0.3 -0.5 1.3)
-   (tf:euler->quaternion :ax 0)))
+   (cl-transforms:make-3d-vector 0.3 -0.5 1.3)
+   (cl-transforms:euler->quaternion :ax 0)))
 (defparameter *park-pose-left-top-slide-down*
-  (tf:make-pose-stamped
+  (cl-tf-datatypes:make-pose-stamped
    "base_link" (ros-time)
-   (tf:make-3d-vector 0.3 0.5 1.3)
-   (tf:euler->quaternion
+   (cl-transforms:make-3d-vector 0.3 0.5 1.3)
+   (cl-transforms:euler->quaternion
     :ax 0 :ay (/ pi -2))))
 (defparameter *park-pose-right-top-slide-down*
-  (tf:make-pose-stamped
+  (cl-tf-datatypes:make-pose-stamped
    "base_link" (ros-time)
-   (tf:make-3d-vector 0.3 -0.5 1.3)
-   (tf:euler->quaternion
+   (cl-transforms:make-3d-vector 0.3 -0.5 1.3)
+   (cl-transforms:euler->quaternion
     :ax 0 :ay (/ pi -2))))
 
 (defun absolute-handle (obj handle
                         &key (handle-offset-pose
-                              (tf:make-identity-pose))
+                              (cl-transforms:make-identity-pose))
                           (reorient t))
   "Transforms the relative handle location `handle' of object `obj'
 into the object's coordinate system and returns the appropriate
@@ -107,14 +107,14 @@ applied."
                                                  'desig-props:pose))))
          (relative-handle-loc (desig-prop-value handle 'at))
          (relative-handle-pose (cl-transforms:transform-pose
-                                (tf:pose->transform
+                                (cl-transforms:pose->transform
                                  (reference relative-handle-loc))
                                 handle-offset-pose))
-         (pose-stamped (tf:pose->pose-stamped
-                        (tf:frame-id absolute-object-pose-stamped)
-                        (tf:stamp absolute-object-pose-stamped)
+         (pose-stamped (cl-tf-datatypes:pose->pose-stamped
+                        (cl-tf-datatypes:frame-id absolute-object-pose-stamped)
+                        (cl-tf-datatypes:stamp absolute-object-pose-stamped)
                         (cl-transforms:transform-pose
-                         (tf:pose->transform
+                         (cl-transforms:pose->transform
                           absolute-object-pose-stamped)
                          relative-handle-pose))))
     (make-designator 'object (loop for desc-elem in (description handle)
@@ -266,7 +266,7 @@ configuration."
   (let ((pose (cond (arm-offset-pose (relative-pose pose arm-offset-pose))
                     (t pose))))
     (roslisp:publish (roslisp:advertise "/testpose" "geometry_msgs/PoseStamped")
-                     (tf:pose-stamped->msg pose))
+                     (cl-tf2:to-msg pose))
     (cpl:with-failure-handling
         ((moveit:no-ik-solution (f)
            (declare (ignore f))
@@ -287,7 +287,7 @@ configuration."
                             &key
                               allowed-collision-objects
                               (arms-offset-pose
-                               (tf:make-identity-pose))
+                               (cl-transforms:make-identity-pose))
                               highlight-links)
   (loop for arm in arms
         for distance = (reaching-length

--- a/pr2_manipulation_process_module/src/kinematics.lisp
+++ b/pr2_manipulation_process_module/src/kinematics.lisp
@@ -81,8 +81,9 @@ is fundamentally different."
                       (crs:prolog
                        `(planning-group ,side ?group)))))
          (pose-in-tll
-           (cl-tf2:ensure-pose-stamped-transformed
-            *tf2* pose "/torso_lift_link" :use-current-ros-time t)))
+           (cl-tf2:transform-pose
+            *tf2-buffer* :pose pose :target-frame  "/torso_lift_link"
+                         :timeout *tf-default-timeout* :use-current-ros-time t)))
     (let ((state-0 (moveit:plan-link-movement
                     wrist-frame arm-group pose-in-tll
                     :touch-links

--- a/pr2_manipulation_process_module/src/package.lisp
+++ b/pr2_manipulation_process_module/src/package.lisp
@@ -44,7 +44,7 @@
                 manipulator-link
                 planning-group)
   (:import-from roslisp ros-info ros-warn ros-error ros-time)
-  (:import-from cram-roslisp-common *tf2*)
+  (:import-from cram-roslisp-common *tf2-buffer*)
   (:export pr2-manipulation-process-module
            wait-for-controller
            reorient-object)

--- a/pr2_manipulation_process_module/src/utils.lisp
+++ b/pr2_manipulation_process_module/src/utils.lisp
@@ -144,14 +144,17 @@ satisfy these constraints is returned."
 (defun publish-pose (pose topic)
   (let* ((pose-stamped
            (case (class-name (class-of pose))
-             (cl-transforms:pose (tf:pose->pose-stamped "/map" (ros-time) pose))
-             (cl-tf:pose-stamped
-              (cond ((or (string= (tf:frame-id pose) "map")
-                         (string= (tf:frame-id pose) "/map"))
+             (cl-transforms:pose (cl-tf-datatypes:pose->pose-stamped "/map" (ros-time) pose))
+             (cl-tf-datatypes:pose-stamped
+              (cond ((or (string= (cl-tf-datatypes:frame-id pose) "map")
+                         (string= (cl-tf-datatypes:frame-id pose) "/map"))
                      pose)
-                    (t (cl-tf2:ensure-pose-stamped-transformed
-                        *tf2* pose "/map" :use-current-ros-time t))))))
-         (pose-stamped-msg (tf:pose-stamped->msg pose-stamped)))
+                    (t (cl-tf2:transform-pose
+                        *tf2-buffer*
+                        :pose pose :target-frame "/map"
+                        :timeout cram-roslisp-common:*tf-default-timeout*
+                        :use-current-ros-time t))))))
+         (pose-stamped-msg (cl-tf2:to-msg pose-stamped)))
     (roslisp:publish
      (roslisp:advertise topic "geometry_msgs/PoseStamped")
      pose-stamped-msg)))

--- a/pr2_navigation_process_module/src/package.lisp
+++ b/pr2_navigation_process_module/src/package.lisp
@@ -38,5 +38,5 @@
         #:cram-roslisp-common
         #:cram-plan-failures)
   (:export #:pr2-navigation-process-module #:*navigation-enabled*)
-  (:import-from cram-roslisp-common *tf2*)
+  (:import-from cram-roslisp-common *tf2-buffer*)
   (:desig-properties #:type #:navigation #:goal #:to))

--- a/pr2_reachability_costmap/src/package.lisp
+++ b/pr2_reachability_costmap/src/package.lisp
@@ -30,7 +30,7 @@
 
 (defpackage pr2-reachability-costmap
   (:use #:common-lisp #:location-costmap #:cram-reasoning)
-  (:import-from cram-roslisp-common *tf2*)
+  (:import-from cram-roslisp-common *tf2-buffer*)
   (:export generate-map-main reachability-map side maximum minimum
            resolution orientations reachability-map pose-reachable-p
            pose-reachability inverse-reachability-map origin

--- a/pr2_reachability_costmap/src/ros.lisp
+++ b/pr2_reachability_costmap/src/ros.lisp
@@ -84,8 +84,9 @@
          (roslisp:make-request
           "iai_kinematics_msgs/GetPositionIK"
           (:ik_link_name :ik_request) ik-link
-          (:pose_stamped :ik_request) (tf:pose-stamped->msg
-                                       (tf:pose->pose-stamped ik-base-frame 0.0 pose))
+          (:pose_stamped :ik_request) (cl-tf2:to-msg
+                                       (cl-tf-datatypes:pose->pose-stamped
+                                        ik-base-frame 0.0 pose))
           (:joint_state :ik_seed_state :ik_request) (make-seed-state service-namespace)
           :timeout 1.0))
       ;; TODO(moesenle): Use constant instead of number here.


### PR DESCRIPTION
This is a part of a series of pull requests concerning the switch from TF to TF2.
All the PRs are:

roslisp_common: https://github.com/ros/roslisp_common/pull/23
cram_highlevel: https://github.com/cram-code/cram_highlevel/pull/46
cram_physics: https://github.com/cram-code/cram_physics/pull/23
cram_pr2: https://github.com/cram-code/cram_pr2/pull/10
cram_bridge: https://github.com/cram-code/cram_bridge/pull/21

There is still a problem with TF for projection as the joint state publisher from moveit interferes with the transforms published from projection. This should not affect the execution on the real robot.

One important change is to use `transform-pose` instead of `ensure-pose-...` as the latter would block infinitely if a transform would not be provided to TF. The function `transfrom-pose` has an argument called `timeout` which specifies in seconds how long to wait for the transform before giving up. The default value is specified in `cram-roslisp-common:*tf-default-timeout*`. So, before starting your scenarios set it up for a reasonable value, e.g. 10 seconds or more when working on a real robot.
